### PR TITLE
check to see if  $_wp_additional_image_sizes is set

### DIFF
--- a/php/pixelate.php
+++ b/php/pixelate.php
@@ -21,6 +21,10 @@ function setup() {
 function add_placeholder_sizes() {
 	global $_wp_additional_image_sizes;
 
+	if( !isset( $_wp_additional_image_sizes ) ){
+		$_wp_additional_image_sizes = array();
+	}
+
 	$new_sizes = array();
 
 	foreach( get_intermediate_image_sizes() as $name ) {


### PR DESCRIPTION
If a user has not added a custom image size $_wp_additional_image_sizes is null and  array_merge( $_wp_additional_image_sizes, $new_sizes ) error out because parameter one is not an array. 
